### PR TITLE
Add sentinel job for required status checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,8 +3,6 @@ name: PR Checks
 on:
   pull_request:
     branches: ["main"]
-  push:
-    branches: ["claude/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
- Add 'all-checks-pass' job that depends on all other jobs
- This creates a single status check for GitHub branch protection
- Allows migration-check to be skipped without failing the build
- Use this job name in branch protection rules