### PR TITLE
Implement homepage with locked-in hero variant 1

### DIFF
--- a/apps/website/src/__tests__/example.test.tsx
+++ b/apps/website/src/__tests__/example.test.tsx
@@ -3,10 +3,15 @@ import { render, screen } from "@testing-library/react";
 import HomePage from "../app/page";
 
 describe("HomePage", () => {
-  it("renders the main heading", () => {
+  it("renders the hero section with main heading", () => {
     render(<HomePage />);
-    const heading = screen.getByRole("heading", { name: /personal website/i });
+    const heading = screen.getByRole("heading", { name: /I'm Andrew Aarestad/i });
     expect(heading).toBeInTheDocument();
+  });
+
+  it("displays the design process section", () => {
+    render(<HomePage />);
+    expect(screen.getByRole("heading", { name: /design process/i })).toBeInTheDocument();
   });
 
   it("displays the technology stack", () => {

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -1,35 +1,27 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { HomepageHero } from "@/components/homepage-hero";
 
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24 bg-canvas">
-      <div className="z-10 w-full max-w-5xl items-center justify-between">
-        <h1 className="text-4xl font-bold mb-8 text-center text-black">Personal Website</h1>
-        <div className="space-y-4 text-center">
-          <p className="text-xl text-text-secondary">
-            Built with Next.js 15, TypeScript, and Tailwind CSS
+    <main className="min-h-screen bg-canvas">
+      {/* Hero Section - Variant 1: Direct */}
+      <HomepageHero />
+
+      {/* Design Process Section */}
+      <section className="container mx-auto px-6 py-16 max-w-5xl">
+        <div className="mb-12">
+          <h2 className="text-h3 font-bold text-black mb-3">Design Process</h2>
+          <p className="text-body-lg text-text-secondary max-w-2xl">
+            This site is built using a design-first workflow with AI assistance. Explore the mood boards and design explorations below.
           </p>
-          <p className="text-lg text-text-secondary">A playground for AI-assisted development</p>
+        </div>
 
-          {/* Design System Mood Board Link */}
-          <div className="mt-12 mb-4 p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border border-border-default">
-            <h2 className="text-2xl font-bold text-black mb-3">🎨 Design System Mood Board</h2>
-            <p className="text-body text-text-primary mb-6 max-w-2xl mx-auto">
-              Check out our comprehensive design system showcasing colors, typography, components,
-              and real-world examples. Built with the art studio aesthetic.
-            </p>
-            <Link href="/design-preview/v1-initial">
-              <Button size="lg" className="bg-vermillion hover:bg-vermillion-dark">
-                View Mood Board →
-              </Button>
-            </Link>
-          </div>
-
+        <div className="space-y-6">
           {/* Mobile Hero Component Link */}
-          <div className="mb-8 p-8 bg-surface rounded-xl border-2 border-border-default">
-            <h2 className="text-2xl font-bold text-black mb-3">📱 Mobile Hero Component</h2>
-            <p className="text-body text-text-primary mb-6 max-w-2xl mx-auto">
+          <div className="p-8 bg-surface rounded-xl border-2 border-border-default hover:border-blue transition-colors">
+            <h3 className="text-h5 font-bold text-black mb-3">Mobile Hero Component</h3>
+            <p className="text-body text-text-secondary mb-6 max-w-2xl">
               Preview the homepage hero component designed for mobile screens. Three variants
               following brand voice guidelines: direct, problem-solver, and understated expert.
             </p>
@@ -40,42 +32,62 @@ export default function HomePage() {
             </Link>
           </div>
 
-          {/* Color Exploration Link */}
-          <div className="mb-8 p-8 bg-surface rounded-xl border-2 border-border-default">
-            <h2 className="text-2xl font-bold text-black mb-3">🎨 Color Palette Exploration</h2>
-            <p className="text-body text-text-primary mb-6 max-w-2xl mx-auto">
-              Explore 10 different color palette variations to find the perfect combination.
-              Compare vermillion with emerald, teal, purple, and more accent color options.
+          {/* Design System Mood Board Link */}
+          <div className="p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border border-border-default hover:border-vermillion transition-colors">
+            <h3 className="text-h5 font-bold text-black mb-3">Design System Mood Board</h3>
+            <p className="text-body text-text-secondary mb-6 max-w-2xl">
+              Check out the comprehensive design system showcasing colors, typography, components,
+              and real-world examples. Built with the art studio aesthetic.
             </p>
-            <Link href="/design-preview/color-exploration">
-              <Button size="lg" variant="outline" className="border-2 border-blue hover:bg-blue hover:text-white">
-                Explore Color Options →
+            <Link href="/design-preview/v1-initial">
+              <Button size="lg" className="bg-vermillion hover:bg-vermillion-dark">
+                View Mood Board →
               </Button>
             </Link>
           </div>
 
-          <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-4 text-left">
-            <div className="p-6 border border-border-default rounded-lg bg-surface">
-              <h2 className="font-semibold text-lg mb-2 text-black-accent">Next.js 15</h2>
-              <p className="text-sm text-text-secondary">
+          {/* Color Exploration Link */}
+          <div className="p-8 bg-surface rounded-xl border-2 border-border-default hover:border-gold transition-colors">
+            <h3 className="text-h5 font-bold text-black mb-3">Color Palette Exploration</h3>
+            <p className="text-body text-text-secondary mb-6 max-w-2xl">
+              Explore 10 different color palette variations to find the perfect combination.
+              Compare vermillion with emerald, teal, purple, and more accent color options.
+            </p>
+            <Link href="/design-preview/color-exploration">
+              <Button size="lg" variant="outline" className="border-2 border-gold hover:bg-gold hover:text-white">
+                Explore Color Options →
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Tech Stack Section */}
+      <section className="bg-surface border-t border-border-light">
+        <div className="container mx-auto px-6 py-16 max-w-5xl">
+          <h2 className="text-h4 font-bold text-black mb-8">Built With</h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="p-6 border border-border-default rounded-lg bg-canvas hover:border-vermillion transition-colors">
+              <h3 className="font-semibold text-h6 mb-2 text-black-accent">Next.js 15</h3>
+              <p className="text-body-sm text-text-secondary">
                 Modern React framework with App Router and Server Components
               </p>
             </div>
-            <div className="p-6 border border-border-default rounded-lg bg-surface">
-              <h2 className="font-semibold text-lg mb-2 text-black-accent">Turborepo</h2>
-              <p className="text-sm text-text-secondary">
+            <div className="p-6 border border-border-default rounded-lg bg-canvas hover:border-blue transition-colors">
+              <h3 className="font-semibold text-h6 mb-2 text-black-accent">Turborepo</h3>
+              <p className="text-body-sm text-text-secondary">
                 High-performance build system for monorepos
               </p>
             </div>
-            <div className="p-6 border border-border-default rounded-lg bg-surface">
-              <h2 className="font-semibold text-lg mb-2 text-black-accent">shadcn/ui Ready</h2>
-              <p className="text-sm text-text-secondary">
+            <div className="p-6 border border-border-default rounded-lg bg-canvas hover:border-gold transition-colors">
+              <h3 className="font-semibold text-h6 mb-2 text-black-accent">shadcn/ui Ready</h3>
+              <p className="text-body-sm text-text-secondary">
                 Configured for beautiful UI components
               </p>
             </div>
           </div>
         </div>
-      </div>
+      </section>
     </main>
   );
 }

--- a/apps/website/src/components/homepage-hero.tsx
+++ b/apps/website/src/components/homepage-hero.tsx
@@ -6,7 +6,7 @@ interface HomepageHeroProps {
 }
 
 export function HomepageHero({
-  variant = "understated",
+  variant = "direct",
   showAccent = true,
 }: HomepageHeroProps) {
   return (


### PR DESCRIPTION
- Set default variant to "direct" (Variant 1) in HomepageHero component
- Redesign homepage to feature HomepageHero at the top
- Add "Design Process" section with links to mood boards
- Keep "Built With" tech stack section
- Update tests to match new homepage structure
- All mood board variants remain functional at /design-preview/mobile-hero

This locks in Variant 1 ("I'm Andrew Aarestad. I build production ML systems.")
as the default hero while preserving all three variants on the mood board page
for future reference.