### PR TITLE
Fix overfitted unit test for hero heading

### DIFF
--- a/apps/website/src/__tests__/example.test.tsx
+++ b/apps/website/src/__tests__/example.test.tsx
@@ -5,7 +5,9 @@ import HomePage from "../app/page";
 describe("HomePage", () => {
   it("renders the hero section with main heading", () => {
     render(<HomePage />);
-    const heading = screen.getByRole("heading", { name: /I'm Andrew Aarestad/i });
+    // Check for presence of main heading containing "Andrew" - not exact text
+    // This allows copy to evolve without breaking tests
+    const heading = screen.getByRole("heading", { name: /andrew/i, level: 1 });
     expect(heading).toBeInTheDocument();
   });
 


### PR DESCRIPTION
The test was checking for exact copy ("I'm Andrew Aarestad") which broke when the hero text changed to "Hi, I'm Andrew."

Unit tests should focus on functional behavior, not implementation details or exact copy. Updated to check for:
- Presence of an h1 heading
- Contains "Andrew" (case insensitive)
- Allows copy to evolve without breaking tests

This makes the test more maintainable and focused on structure rather than content.