### PR TITLE
Update Design Process section on homepage

### DIFF
--- a/apps/website/src/__tests__/example.test.tsx
+++ b/apps/website/src/__tests__/example.test.tsx
@@ -9,9 +9,19 @@ describe("HomePage", () => {
     expect(heading).toBeInTheDocument();
   });
 
-  it("displays the design process section", () => {
+  it("displays the design process section with title and subtitle", () => {
     render(<HomePage />);
     expect(screen.getByRole("heading", { name: /design process/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/This site is built using a design-first workflow/i),
+    ).toBeInTheDocument();
+  });
+
+  it("displays link to design process page", () => {
+    render(<HomePage />);
+    const link = screen.getByRole("link", { name: /View Design Process/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/design-process");
   });
 
   it("displays the technology stack", () => {

--- a/apps/website/src/app/design-process/__tests__/page.test.tsx
+++ b/apps/website/src/app/design-process/__tests__/page.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DesignProcessPage from "../page";
+
+describe("DesignProcessPage", () => {
+  it("renders the page title", () => {
+    render(<DesignProcessPage />);
+    const heading = screen.getByRole("heading", { name: /^Design Process$/i, level: 1 });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it("displays the meta-project section", () => {
+    render(<DesignProcessPage />);
+    expect(screen.getByRole("heading", { name: /a meta-project/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/This website is inherently recursive/i),
+    ).toBeInTheDocument();
+  });
+
+  it("displays the design-first workflow section with timeline", () => {
+    render(<DesignProcessPage />);
+    expect(
+      screen.getByRole("heading", { name: /the design-first workflow/i }),
+    ).toBeInTheDocument();
+    // Check for timeline phases - use getAllByText since some text appears in headings and body
+    const phases = [
+      /Brand Foundation/i,
+      /Visual System/i,
+      /Review & Refine/i,
+      /Build & Deploy/i,
+    ];
+    phases.forEach((phase) => {
+      expect(screen.getByText(phase)).toBeInTheDocument();
+    });
+  });
+
+  it("displays the mood board links section", () => {
+    render(<DesignProcessPage />);
+    expect(
+      screen.getByRole("heading", { name: /explore the design evolution/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays all three mood board card links", () => {
+    render(<DesignProcessPage />);
+    const mobileHeroLink = screen.getByRole("link", { name: /view mobile hero/i });
+    const moodBoardLink = screen.getByRole("link", { name: /view mood board/i });
+    const colorLink = screen.getByRole("link", { name: /explore color options/i });
+
+    expect(mobileHeroLink).toBeInTheDocument();
+    expect(mobileHeroLink).toHaveAttribute("href", "/design-preview/mobile-hero");
+
+    expect(moodBoardLink).toBeInTheDocument();
+    expect(moodBoardLink).toHaveAttribute("href", "/design-preview/v1-initial");
+
+    expect(colorLink).toBeInTheDocument();
+    expect(colorLink).toHaveAttribute("href", "/design-preview/color-exploration");
+  });
+
+  it("displays the AI collaboration section", () => {
+    render(<DesignProcessPage />);
+    expect(
+      screen.getByRole("heading", { name: /built with ai collaboration/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/This entire project is built using Claude Code/i)).toBeInTheDocument();
+  });
+
+  it("displays GitHub link", () => {
+    render(<DesignProcessPage />);
+    const githubLink = screen.getByRole("link", { name: /view on github/i });
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/andrewaarestad/personal-website",
+    );
+    expect(githubLink).toHaveAttribute("target", "_blank");
+    expect(githubLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("displays back to home link", () => {
+    render(<DesignProcessPage />);
+    const homeLink = screen.getByRole("link", { name: /back to home/i });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+});

--- a/apps/website/src/app/design-process/page.tsx
+++ b/apps/website/src/app/design-process/page.tsx
@@ -178,7 +178,7 @@ export default function DesignProcessPage() {
             </div>
 
             {/* Design System Mood Board Link */}
-            <div className="p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border border-border-default hover:border-vermillion transition-colors">
+            <div className="p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border-2 border-border-default hover:border-vermillion transition-colors">
               <h3 className="text-h5 font-bold text-black mb-3">
                 Design System Mood Board
               </h3>

--- a/apps/website/src/app/design-process/page.tsx
+++ b/apps/website/src/app/design-process/page.tsx
@@ -1,0 +1,272 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Design Process | Andrew Aarestad",
+  description:
+    "A transparent look at building a personal website using design-first workflows and AI-assisted development. Explore the phases, mood boards, and the meta-project of showcasing web development through a developer's personal site.",
+  openGraph: {
+    title: "Design Process | Andrew Aarestad",
+    description:
+      "Building a website about someone who builds websites - a transparent look at design-first workflows and AI collaboration.",
+  },
+};
+
+export default function DesignProcessPage() {
+  return (
+    <main className="min-h-screen bg-canvas">
+      {/* Hero Section */}
+      <section className="container mx-auto px-6 py-16 max-w-5xl">
+        <div className="mb-16">
+          <h1 className="text-h2 font-bold text-black mb-4">Design Process</h1>
+          <p className="text-h5 text-text-secondary max-w-3xl font-normal">
+            This site is built using a design-first workflow with AI assistance.
+            Explore the phases, mood boards, and the recursive journey of building
+            a website about someone who builds websites.
+          </p>
+        </div>
+
+        {/* Meta-Project Section */}
+        <div className="mb-16">
+          <h2 className="text-h3 font-bold text-black mb-6">A Meta-Project</h2>
+          <div className="space-y-4 text-body text-text-secondary max-w-3xl">
+            <p>
+              This website is inherently recursive: it's a personal site for a web
+              developer, built to showcase the very skills it represents. Rather than
+              just presenting a finished product, I'm documenting the entire design
+              and development process—making the work itself part of the portfolio.
+            </p>
+            <p>
+              Transparency is a core value here. Every design decision, iteration, and
+              pivot is preserved in the mood boards below. This approach transforms a
+              standard portfolio into a living demonstration of design-first thinking,
+              AI-assisted development, and iterative refinement.
+            </p>
+            <p>
+              By building in public and treating the process as content, this project
+              becomes more than a website—it's proof of concept for modern web
+              development practices, showing how thoughtful design and AI collaboration
+              can work together to create something meaningful.
+            </p>
+          </div>
+        </div>
+
+        {/* Visual Timeline Section */}
+        <div className="mb-16">
+          <h2 className="text-h3 font-bold text-black mb-8">The Design-First Workflow</h2>
+          <div className="space-y-8">
+            {/* Timeline Visual */}
+            <div className="relative">
+              {/* Vertical line connector - hidden on mobile, shown on md+ */}
+              <div className="hidden md:block absolute left-8 top-0 bottom-0 w-0.5 bg-gradient-to-b from-vermillion via-blue to-gold" />
+
+              {/* Phase 1: Brand Foundation */}
+              <div className="relative flex gap-6 mb-8">
+                <div className="flex-shrink-0 w-16 h-16 rounded-full bg-vermillion flex items-center justify-center text-white font-bold text-h5 z-10 border-4 border-canvas">
+                  1
+                </div>
+                <div className="flex-grow pt-2">
+                  <h3 className="text-h5 font-bold text-black mb-2">Brand Foundation</h3>
+                  <p className="text-body text-text-secondary">
+                    Define mission, persona, voice & tone, and core values. Establish
+                    the identity before any visual work begins.
+                  </p>
+                </div>
+              </div>
+
+              {/* Phase 2: Visual System */}
+              <div className="relative flex gap-6 mb-8">
+                <div className="flex-shrink-0 w-16 h-16 rounded-full bg-blue flex items-center justify-center text-white font-bold text-h5 z-10 border-4 border-canvas">
+                  2
+                </div>
+                <div className="flex-grow pt-2">
+                  <h3 className="text-h5 font-bold text-black mb-2">Visual System</h3>
+                  <p className="text-body text-text-secondary">
+                    Create color palettes, typography scales, spacing systems, and
+                    component patterns. Build the design language.
+                  </p>
+                </div>
+              </div>
+
+              {/* Phase 3: Mood Boards */}
+              <div className="relative flex gap-6 mb-8">
+                <div className="flex-shrink-0 w-16 h-16 rounded-full bg-gold flex items-center justify-center text-white font-bold text-h5 z-10 border-4 border-canvas">
+                  3
+                </div>
+                <div className="flex-grow pt-2">
+                  <h3 className="text-h5 font-bold text-black mb-2">
+                    Interactive Mood Boards
+                  </h3>
+                  <p className="text-body text-text-secondary">
+                    Deploy working previews to Vercel for real-world testing. See
+                    designs in context, not just in Figma.
+                  </p>
+                </div>
+              </div>
+
+              {/* Phase 4: Iteration */}
+              <div className="relative flex gap-6 mb-8">
+                <div className="flex-shrink-0 w-16 h-16 rounded-full bg-vermillion flex items-center justify-center text-white font-bold text-h5 z-10 border-4 border-canvas">
+                  4
+                </div>
+                <div className="flex-grow pt-2">
+                  <h3 className="text-h5 font-bold text-black mb-2">Review & Refine</h3>
+                  <p className="text-body text-text-secondary">
+                    Gather feedback, test on devices, refine the approach. Repeat until
+                    the design feels right.
+                  </p>
+                </div>
+              </div>
+
+              {/* Phase 5: Implementation */}
+              <div className="relative flex gap-6">
+                <div className="flex-shrink-0 w-16 h-16 rounded-full bg-blue flex items-center justify-center text-white font-bold text-h5 z-10 border-4 border-canvas">
+                  5
+                </div>
+                <div className="flex-grow pt-2">
+                  <h3 className="text-h5 font-bold text-black mb-2">
+                    Build & Deploy
+                  </h3>
+                  <p className="text-body text-text-secondary">
+                    Implement the approved design with production-quality code. The
+                    design system guides every component.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Why This Approach */}
+            <div className="mt-12 p-8 bg-gradient-to-br from-blue-light/30 via-gold-light/30 to-vermillion-light/30 rounded-xl border border-border-default">
+              <h3 className="text-h5 font-bold text-black mb-3">Why Design-First?</h3>
+              <p className="text-body text-text-secondary">
+                Starting with design prevents scope creep, ensures visual consistency,
+                and creates a clear roadmap for implementation. By validating design
+                decisions early through mood boards, we avoid costly refactors and
+                maintain quality throughout the development process.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Explore Design Evolution Section */}
+        <div className="mb-16">
+          <h2 className="text-h3 font-bold text-black mb-6">
+            Explore the Design Evolution
+          </h2>
+          <p className="text-body-lg text-text-secondary mb-8 max-w-2xl">
+            Check out the interactive mood boards that showcase different phases of
+            the design process. Each represents real explorations and iterations.
+          </p>
+
+          <div className="space-y-6">
+            {/* Mobile Hero Component Link */}
+            <div className="p-8 bg-surface rounded-xl border-2 border-border-default hover:border-blue transition-colors">
+              <h3 className="text-h5 font-bold text-black mb-3">
+                Mobile Hero Component
+              </h3>
+              <p className="text-body text-text-secondary mb-6 max-w-2xl">
+                Preview the homepage hero component designed for mobile screens. Three
+                variants following brand voice guidelines: direct, problem-solver, and
+                understated expert.
+              </p>
+              <Link href="/design-preview/mobile-hero">
+                <Button size="lg" className="bg-blue hover:bg-blue-dark text-white">
+                  View Mobile Hero →
+                </Button>
+              </Link>
+            </div>
+
+            {/* Design System Mood Board Link */}
+            <div className="p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border border-border-default hover:border-vermillion transition-colors">
+              <h3 className="text-h5 font-bold text-black mb-3">
+                Design System Mood Board
+              </h3>
+              <p className="text-body text-text-secondary mb-6 max-w-2xl">
+                Check out the comprehensive design system showcasing colors, typography,
+                components, and real-world examples. Built with the art studio aesthetic.
+              </p>
+              <Link href="/design-preview/v1-initial">
+                <Button size="lg" className="bg-vermillion hover:bg-vermillion-dark">
+                  View Mood Board →
+                </Button>
+              </Link>
+            </div>
+
+            {/* Color Exploration Link */}
+            <div className="p-8 bg-surface rounded-xl border-2 border-border-default hover:border-gold transition-colors">
+              <h3 className="text-h5 font-bold text-black mb-3">
+                Color Palette Exploration
+              </h3>
+              <p className="text-body text-text-secondary mb-6 max-w-2xl">
+                Explore 10 different color palette variations to find the perfect
+                combination. Compare vermillion with emerald, teal, purple, and more
+                accent color options.
+              </p>
+              <Link href="/design-preview/color-exploration">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="border-2 border-gold hover:bg-gold hover:text-white"
+                >
+                  Explore Color Options →
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* AI-Assisted Development Section */}
+        <div className="mb-16">
+          <h2 className="text-h3 font-bold text-black mb-6">
+            Built with AI Collaboration
+          </h2>
+          <div className="space-y-4 text-body text-text-secondary max-w-3xl">
+            <p>
+              This entire project is built using Claude Code, demonstrating how AI can
+              assist in the full development lifecycle—from design exploration to
+              production deployment. The AI helps maintain consistency, suggests
+              improvements, and accelerates implementation while I guide the creative
+              direction and make final decisions.
+            </p>
+            <p>
+              The workflow balances AI assistance with human creativity: Claude handles
+              repetitive tasks, enforces code quality, and explores design variations,
+              while I focus on strategy, user experience, and the narrative. This
+              collaboration model represents a practical approach to modern web
+              development, where AI augments rather than replaces human expertise.
+            </p>
+            <p>
+              <strong className="text-black">This project is open source.</strong> Check
+              out the full codebase on GitHub to see the implementation details, commit
+              history, and AI-assisted development workflow in action.
+            </p>
+          </div>
+          <div className="mt-8 flex gap-4">
+            <Link
+              href="https://github.com/andrewaarestad/personal-website"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button
+                size="lg"
+                className="bg-black hover:bg-black/90 text-white"
+              >
+                View on GitHub →
+              </Button>
+            </Link>
+            <Link href="/">
+              <Button
+                size="lg"
+                variant="outline"
+                className="border-2 border-blue hover:bg-blue hover:text-white"
+              >
+                ← Back to Home
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -17,52 +17,26 @@ export default function HomePage() {
         <div className="mb-12">
           <h2 className="text-h3 font-bold text-black mb-3">Design Process</h2>
           <p className="text-body-lg text-text-secondary max-w-2xl">
-            This site is built using a design-first workflow with AI assistance. Explore the mood boards and design explorations below.
+            This site is built using a design-first workflow with AI assistance.
+            Learn about the phases, explore interactive mood boards, and see the
+            meta-project of building a website about someone who builds websites.
           </p>
         </div>
 
-        <div className="space-y-6">
-          {/* Mobile Hero Component Link */}
-          <div className="p-8 bg-surface rounded-xl border-2 border-border-default hover:border-blue transition-colors">
-            <h3 className="text-h5 font-bold text-black mb-3">Mobile Hero Component</h3>
-            <p className="text-body text-text-secondary mb-6 max-w-2xl">
-              Preview the homepage hero component designed for mobile screens. Three variants
-              following brand voice guidelines: direct, problem-solver, and understated expert.
-            </p>
-            <Link href="/design-preview/mobile-hero">
-              <Button size="lg" className="bg-blue hover:bg-blue-dark text-white">
-                View Mobile Hero →
-              </Button>
-            </Link>
-          </div>
-
-          {/* Design System Mood Board Link */}
-          <div className="p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border border-border-default hover:border-vermillion transition-colors">
-            <h3 className="text-h5 font-bold text-black mb-3">Design System Mood Board</h3>
-            <p className="text-body text-text-secondary mb-6 max-w-2xl">
-              Check out the comprehensive design system showcasing colors, typography, components,
-              and real-world examples. Built with the art studio aesthetic.
-            </p>
-            <Link href="/design-preview/v1-initial">
-              <Button size="lg" className="bg-vermillion hover:bg-vermillion-dark">
-                View Mood Board →
-              </Button>
-            </Link>
-          </div>
-
-          {/* Color Exploration Link */}
-          <div className="p-8 bg-surface rounded-xl border-2 border-border-default hover:border-gold transition-colors">
-            <h3 className="text-h5 font-bold text-black mb-3">Color Palette Exploration</h3>
-            <p className="text-body text-text-secondary mb-6 max-w-2xl">
-              Explore 10 different color palette variations to find the perfect combination.
-              Compare vermillion with emerald, teal, purple, and more accent color options.
-            </p>
-            <Link href="/design-preview/color-exploration">
-              <Button size="lg" variant="outline" className="border-2 border-gold hover:bg-gold hover:text-white">
-                Explore Color Options →
-              </Button>
-            </Link>
-          </div>
+        <div className="p-8 bg-gradient-to-br from-vermillion-light/30 via-blue-light/30 to-gold-light/30 rounded-xl border-2 border-border-default hover:border-vermillion transition-colors">
+          <h3 className="text-h5 font-bold text-black mb-3">
+            Explore the Full Design Journey
+          </h3>
+          <p className="text-body text-text-secondary mb-6 max-w-2xl">
+            Dive into the complete design process, from brand foundation to
+            implementation. See the 5-phase workflow, explore interactive mood boards,
+            and understand how AI collaboration shapes modern web development.
+          </p>
+          <Link href="/design-process">
+            <Button size="lg" className="bg-vermillion hover:bg-vermillion-dark">
+              View Design Process →
+            </Button>
+          </Link>
         </div>
       </section>
 


### PR DESCRIPTION
- Create new /design-process page with comprehensive content
- Add meta-project narrative explaining the recursive nature of building a website for a web developer
- Implement visual timeline showcasing the 5-phase design-first workflow
- Move mood board cards from homepage to dedicated page
- Add GitHub repository link for open-source transparency
- Update homepage to use single CTA card linking to design process page
- Update and create tests for both pages
- All tests, type-checks, and builds passing

The new design process page provides a deeper look into the project methodology, emphasizing transparency, AI collaboration, and design-first thinking.