### PR TITLE
Update projects page metadata to reflect broader scope

### DIFF
--- a/apps/website/src/app/projects/page.tsx
+++ b/apps/website/src/app/projects/page.tsx
@@ -40,7 +40,7 @@ export default function ProjectsPage() {
 
             <ProjectOverview
               title="Ambient Temperature Estimation"
-              description="Multi-sensor data fusion system for ambient temperature estimation. Combined physical/statistical modeling with edge inference to create a mesh network of weather data using cell phones. Open sourced the key tech."
+              description="Multi-sensor data fusion system for ambient temperature estimation. Combined physical/statistical modeling with edge inference to create a network of weather stations using cell phones. Open sourced the key tech."
               imageUrl="https://placehold.co/800x600/7C3AED/FFFFFF/png?text=Temperature+Estimation"
               imageAlt="Ambient Temperature Estimation"
               projectSlug="ambient-temperature-estimation"


### PR DESCRIPTION
Changed the meta description from a portfolio-focused message to one that
encompasses both production systems and experimental work. The new copy is
more whimsical and genuine, reflecting that this page will include both
shipped products and technical explorations driven by curiosity.