### PR TITLE
Fix breadcrumb navigation z-index and content overlap issue

### DIFF
--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Breadcrumb } from "@/components/breadcrumb";
+import { MainContent } from "@/components/main-content";
 
 export const metadata: Metadata = {
   title: "Personal Website",
@@ -25,7 +26,7 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         <Breadcrumb />
-        <div>{children}</div>
+        <MainContent>{children}</MainContent>
       </body>
     </html>
   );

--- a/apps/website/src/components/breadcrumb.tsx
+++ b/apps/website/src/components/breadcrumb.tsx
@@ -67,7 +67,7 @@ export function Breadcrumb() {
   return (
     <nav
       className={cn(
-        "fixed top-0 left-0 right-0 z-40 flex items-center gap-2 text-body-sm px-6 py-4 bg-surface/80 backdrop-blur-sm border-b border-border-light mb-8",
+        "fixed top-0 left-0 right-0 z-40 flex items-center gap-2 text-body-sm px-6 py-4 bg-surface/80 backdrop-blur-sm border-b border-border-light",
         "transition-transform duration-300 ease-in-out",
         isVisible ? "translate-y-0" : "-translate-y-full"
       )}

--- a/apps/website/src/components/main-content.tsx
+++ b/apps/website/src/components/main-content.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+interface MainContentProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper component that adds top padding to account for the fixed breadcrumb navigation.
+ * The breadcrumb is hidden on the homepage, so no padding is added there.
+ * The padding ensures page content is never overlapped by the breadcrumb.
+ */
+export function MainContent({ children }: MainContentProps) {
+  const pathname = usePathname();
+  const isHomepage = pathname === "/";
+
+  return (
+    <div
+      className={cn(
+        // Add top padding on all pages except homepage to account for fixed breadcrumb
+        // The breadcrumb has py-4 padding and text content, resulting in ~56px height
+        !isHomepage && "pt-16"
+      )}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Problem:
- Fixed breadcrumb overlapped page content on all pages
- No top padding on content wrapper to account for breadcrumb height
- Ineffective mb-8 class on fixed-position breadcrumb

Solution:
- Created MainContent wrapper component with conditional padding
- Adds pt-16 padding on all pages except homepage (where breadcrumb is hidden)
- Updated layout.tsx to use MainContent wrapper
- Removed ineffective mb-8 from breadcrumb component

This ensures page content is never overlapped by the breadcrumb,
whether visible or hidden via scroll animation.